### PR TITLE
Support showing strokes with pixman and vulkan renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Packages are available for:
 
  - [Wayfire](https://github.com/WayfireWM/wayfire), the current development version, i.e. 0.10.0, after commit [544427d](https://github.com/WayfireWM/wayfire/pull/2613) (see below for compiling on older Wayfire versions)
  - [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) version [0.18](https://gitlab.freedesktop.org/wlroots/wlroots/-/tree/0.18?ref_type=heads).
- - Development libraries for GTK, GDK, glib, gtkmm, gdkmm and boost-serialization (Ubuntu packages: `libglib2.0-dev, libgtk-3-dev, libgtkmm-3.0-dev, libboost-serialization-dev`)
+ - Development libraries for GTK, GDK, glib, cairo, pixman, gtkmm, gdkmm and boost-serialization (Ubuntu packages: `libglib2.0-dev, libgtk-3-dev, libcairo2-dev, libpixman-1-dev, libgtkmm-3.0-dev, libboost-serialization-dev`)
  - `glib-compile-resources` (Ubuntu package: `libglib2.0-dev-bin`)
  - [Vala](https://vala.dev/) compiler (for building, Ubuntu package: `valac`; or use the [no_vala](https://github.com/dkondor/wstroke/tree/no_vala) branch instead)
  - Optional, but highly recommended: [WCM](https://github.com/WayfireWM/wcm) for basic configuration
@@ -59,6 +59,7 @@ The same can be achieved by editing the option `focus_buttons` in the `[core]` s
 
  - Importing saved strokes from "actions" files created with Easystroke (just run `wstroke-config`).
  - Drawing and recognizing strokes.
+ - Drawing strokes with all supported renderer backends (EGL, Vulkan and pixman).
  - Actions on the active view: close, minimize, (un)maximize, move, resize (select "WM Action" and the appropriate action).
  - Actions to activate another Wayfire plugin (typical desktop interactions are under "Global Action"; "Custom Plugin" can be used with giving the plugin activator name directly), only supported for some plugins, see [here](https://github.com/WayfireWM/wayfire/issues/1811).
  - Generating keypresses ("Key" action).
@@ -80,4 +81,5 @@ The same can be achieved by editing the option `focus_buttons` in the `[core]` s
  - Individual settings (which button, timeout) for each pointing device
  - Advanced gestures
  - Touchscreen and pen / stylus support
+ - Drawing strokes with the Vulkan renderer (`WLR_RENDERER=vulkan`) is inefficient (suggestions for improvement are welcome).
 

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,8 @@ wlroots  = dependency('wlroots-0.18')
 wlroots_headers = wlroots.partial_dependency(includes: true, compile_args: true)
 wlserver = dependency('wayland-server')
 glibmm   = dependency('glibmm-2.4')
+cairo    = dependency('cairo')
+pixman   = dependency('pixman-1')
 
 # additional dependencies for GUI
 gtkmm    = dependency('gtkmm-3.0')

--- a/src/easystroke_gestures.cpp
+++ b/src/easystroke_gestures.cpp
@@ -35,6 +35,7 @@
 #include <sys/inotify.h>
 #include <memory>
 #include <filesystem>
+#include <cstring>
 
 #include <cairo.h>
 #include <pixman.h>
@@ -457,13 +458,8 @@ class ws_node_pixman : public ws_node_cairo {
 				for(int y = damage_acc.y; y < damage_acc.y + damage_acc.height; y++) {
 					size_t base_src = y * stride_src;
 					size_t base_dst = y * stride_dst;
-					for(int x = damage_acc.x; x < damage_acc.x + damage_acc.width; x++) {
-						// note: 4 bytes per pixel
-						dst[base_dst + x * 4]     = src[base_src + x * 4];
-						dst[base_dst + x * 4 + 1] = src[base_src + x * 4 + 1];
-						dst[base_dst + x * 4 + 2] = src[base_src + x * 4 + 2];
-						dst[base_dst + x * 4 + 3] = src[base_src + x * 4 + 3];
-					}
+					// note: each pixel is 4 bytes
+					std::memcpy(dst + base_dst + damage_acc.x * 4UL, src + base_src + damage_acc.x * 4UL, damage_acc.width * 4UL);
 				}
 			}
 			

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,7 +30,7 @@ wconf = executable('wstroke-config', wconf_sources,
 
 wslib_sources = ['easystroke_gestures.cpp', 'input_events.cpp', 'actiondb.cc', 'actiondb_plugin.cc', 'gesture.cc', 'stroke.c']
 wslib = shared_module('wstroke', wslib_sources,
-    dependencies: [wayfire, wlroots, wlserver, boost, glibmm],
+    dependencies: [wayfire, wlroots, wlserver, boost, glibmm, cairo, pixman],
     install: true,
     install_dir: wayfire.get_variable(pkgconfig: 'plugindir'),
     cpp_args: ['-Wno-unused-parameter', '-Wno-format-security','-DWAYFIRE_PLUGIN', '-DWLR_USE_UNSTABLE'],


### PR DESCRIPTION
This just uses Cairo for drawing. In the pixman case, this works well, as it can render directly from the cairo surface used. For the vulkan case, this mean re-creating a wlr_texture (and thus re-uploading the full surface to the GPU) every time the stroke is updated which is quite wasteful (however, it still works).